### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ You can see [here a demo](http://rawgit.com/jonataswalker/ol3-contextmenu/master
 ##### CDN Hosted - [jsDelivr](http://www.jsdelivr.com/projects/openlayers.contextmenu)
 Load CSS and Javascript:
 ```HTML
-<link href="//cdn.jsdelivr.net/openlayers.contextmenu/latest/ol3-contextmenu.min.css" rel="stylesheet">
-<script src="//cdn.jsdelivr.net/openlayers.contextmenu/latest/ol3-contextmenu.js"></script>
+<link href="//cdn.jsdelivr.net/npm/ol3-contextmenu@latest/build/ol3-contextmenu.min.css" rel="stylesheet">
+<script src="//cdn.jsdelivr.net/npm/ol3-contextmenu@latest/build/ol3-contextmenu.js"></script>
 ```
 ##### CDN Hosted - UNPKG
 Load CSS and Javascript:


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the links now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/ol3-contextmenu.

Feel free to ping me if you have any questions regarding this change.