### PR TITLE
Rename OpenLayers Dependency : openlayers -> ol

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     ]
   },
   "dependencies": {
-    "openlayers": "^4.4.2"
+    "ol": "^4.4.2"
   },
   "devDependencies": {
     "autoprefixer": "^7.1.6",


### PR DESCRIPTION
To fix build error with OpenLayers package name

yarn install v1.3.2
[1/5] Validating package.json...
[2/5] Resolving packages...
warning ol-contextmenu > openlayers > nomnom@1.8.1: Package no longer supported. Contact support@npmjs.com for more info.