### PR TITLE
Stopped click events propagating to map

### DIFF
--- a/src/internal.js
+++ b/src/internal.js
@@ -217,6 +217,17 @@ export class Internal {
       },
       false
     );
+
+    evt.target.addEventListener(
+      'pointerup',
+      {
+        handleEvent: function(e) {
+          e.stopPropagation(); //Stop pointerup event propogating to map (openlayers simulates a map click on pointer up)
+          evt.target.removeEventListener(e.type, this, false);
+        },
+      },
+      false
+    );
   }
 
   setItemListener(li, index) {


### PR DESCRIPTION
Hi, 
I have put in an event handler to prevent the click events propagating to the map.
Coordinates can still be used in the callbacks if required.
Thanks
Alex 