### PR TITLE
Stopped click events propagating to map

### DIFF
--- a/src/internal.js
+++ b/src/internal.js
@@ -211,9 +211,11 @@ export class Internal {
       'pointerdown',
       {
         handleEvent: function(e) {
-          this_.closeMenu();
-          e.stopPropagation();
-          evt.target.removeEventListener(e.type, this, false);
+          if (this.opened) {
+            this_.closeMenu();
+            e.stopPropagation();
+            evt.target.removeEventListener(e.type, this, false);
+          }
         },
       },
       false

--- a/src/internal.js
+++ b/src/internal.js
@@ -217,6 +217,17 @@ export class Internal {
       },
       false
     );
+
+    evt.target.addEventListener(
+      'pointerup',
+      {
+        handleEvent: function(e) {
+          e.stopPropagation(); //Stop pointerup event propogating to map (openlayers simulates a map click on pointer up)
+          evt.target.removeEventListener(e.type, this, false);
+        },
+      },
+      false
+    );
   }
 
   setItemListener(li, index) {

--- a/src/internal.js
+++ b/src/internal.js
@@ -208,21 +208,11 @@ export class Internal {
 
     //one-time fire
     evt.target.addEventListener(
-      'click',
+      'pointerdown',
       {
         handleEvent: function(e) {
           this_.closeMenu();
-          evt.target.removeEventListener(e.type, this, false);
-        },
-      },
-      false
-    );
-
-    evt.target.addEventListener(
-      'pointerup',
-      {
-        handleEvent: function(e) {
-          e.stopPropagation(); //Stop pointerup event propogating to map (openlayers simulates a map click on pointer up)
+          e.stopPropagation();
           evt.target.removeEventListener(e.type, this, false);
         },
       },


### PR DESCRIPTION
Fixes https://github.com/jonataswalker/ol-contextmenu/issues/176

In open layers a simulated click is created on pointerdown event. We dont want this to propagate to the map, so need to stop default when the context menu is clicked