### PR TITLE
Wait for BEFOREOPEN to complete before openmenu()

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -216,7 +216,9 @@ export default class ContextMenu extends Control {
             evt.preventDefault();
         }
 
-        this.openMenu();
+        setTimeout(() => { 
+            this.openMenu(); 
+        });
 
         evt.target?.addEventListener(
             'pointerdown',


### PR DESCRIPTION
openMenu() might be called before the BEFOREOPEN event is completed. Hence timeout is added to make sure menu is openend afterwards.
Had this issue, cause we are using BEFOREOPEN for adding menuitems depending on the  click position. This might involves async functions and led to menu not opening (first right-click) or contain items twice (second right-click).