### PR TITLE
Fixed two issues and re-added 'open' event

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,6 +156,10 @@
                 console.log({ evt });
             });
 
+            contextmenu.on('open', function (evt) {
+                console.log({ evt });
+            });
+
             map.on('moveend', () => {
                 console.log('moveend', contextmenu.isOpen());
             });

--- a/src/main.ts
+++ b/src/main.ts
@@ -268,8 +268,8 @@ export default class ContextMenu extends Control {
         this.dispatchEvent(
             new ContextMenuEvent({
                 type: CustomEventTypes.BEFOREOPEN,
-                pixel: this.pixel,
-                coordinate: this.coordinate,
+                map: this.map,
+                originalEvent: evt
             })
         );
 
@@ -281,7 +281,7 @@ export default class ContextMenu extends Control {
         }
 
         setTimeout(() => { 
-            this.openMenu(); 
+            this.openMenu(evt); 
         });
 
         evt.target?.addEventListener(
@@ -296,7 +296,7 @@ export default class ContextMenu extends Control {
         );
     }
 
-    protected openMenu() {
+    protected openMenu(evt: MouseEvent) {
         if (this.menuEntries.size === 0) return;
 
         this.opened = true;
@@ -306,8 +306,8 @@ export default class ContextMenu extends Control {
         this.dispatchEvent(
             new ContextMenuEvent({
                 type: CustomEventTypes.OPEN,
-                pixel: this.pixel,
-                coordinate: this.coordinate,
+                map: this.map,
+                originalEvent: evt
             })
         );
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,5 @@
 import type { Coordinate } from 'ol/coordinate';
-import type { Pixel } from 'ol/pixel';
-import { Map as OlMap } from 'ol';
-import BaseEvent from 'ol/events/Event.js';
+import { Map as OlMap, MapBrowserEvent } from 'ol';
 
 export enum EventTypes {
     CONTEXTMENU = 'contextmenu',
@@ -16,18 +14,13 @@ export enum CustomEventTypes {
     ADD_MENU_ENTRY = 'add-menu-entry',
 }
 
-export class ContextMenuEvent extends BaseEvent {
-    public coordinate: Coordinate;
-    public pixel: Pixel;
-
+export class ContextMenuEvent extends MapBrowserEvent<MouseEvent> {
     constructor(options: {
         type: `${CustomEventTypes.BEFOREOPEN}` | `${CustomEventTypes.OPEN}`;
-        coordinate: Coordinate;
-        pixel: Pixel;
+        map: OlMap;
+        originalEvent: MouseEvent;
     }) {
-        super(options.type);
-        this.pixel = options.pixel;
-        this.coordinate = options.coordinate;
+        super(options.type, options.map, options.originalEvent);
     }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import type { Coordinate } from 'ol/coordinate';
 import type { Pixel } from 'ol/pixel';
 import { Map as OlMap } from 'ol';
-import BaseEvent from 'ol/events/Event';
+import BaseEvent from 'ol/events/Event.js';
 
 export enum EventTypes {
     CONTEXTMENU = 'contextmenu',
@@ -16,9 +16,19 @@ export enum CustomEventTypes {
     ADD_MENU_ENTRY = 'add-menu-entry',
 }
 
-export interface ContextMenuEvent extends BaseEvent {
-    coordinate: Coordinate;
-    pixel: Pixel;
+export class ContextMenuEvent extends BaseEvent {
+    public coordinate: Coordinate;
+    public pixel: Pixel;
+
+    constructor(options: {
+        type: `${CustomEventTypes.BEFOREOPEN}` | `${CustomEventTypes.OPEN}`;
+        coordinate: Coordinate;
+        pixel: Pixel;
+    }) {
+        super(options.type);
+        this.pixel = options.pixel;
+        this.coordinate = options.coordinate;
+    }
 }
 
 export type CallbackObject = {

--- a/test/instance.spec.ts
+++ b/test/instance.spec.ts
@@ -1,6 +1,9 @@
+import OlMap from 'ol/Map';
+import BaseEvent from 'ol/events/Event';
+
 import { DEFAULT_ITEMS, DEFAULT_OPTIONS } from '../src/constants';
 import ContextMenu from '../src/main';
-import { Item } from '../src/types';
+import { ContextMenuEvent, Item } from '../src/types';
 
 const items: Item[] = [
     '-',
@@ -45,6 +48,11 @@ describe('Instance options', () => {
 
 describe('Instance methods', () => {
     const menu = new ContextMenu();
+
+    // Add map to initialize the emitter
+    new OlMap({
+        controls: [menu],
+    });
 
     test('getDefaultItems()', () => {
         expect(toJSON(menu.getDefaultItems())).toEqual(toJSON(DEFAULT_ITEMS));
@@ -102,4 +110,22 @@ describe('Throw errors', () => {
             new ContextMenu('foo');
         }).toThrow();
     });
+});
+
+// EVENTS
+// The lines below are not a test per se, but as an ESLint indicator if the events are not correctly declared
+const context = new ContextMenu();
+
+context.on('beforeopen', (evt: ContextMenuEvent) => {
+    evt.pixel;
+    evt.coordinate;
+});
+
+context.on('open', (evt: ContextMenuEvent) => {
+    evt.pixel;
+    evt.coordinate;
+});
+
+context.on('close', (evt: BaseEvent) => {
+    evt.target;
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,9 +9,10 @@ import { CSS_CLASSES } from './src/constants';
 const pkg = JSON.parse(readFileSync('./package.json', 'utf8'));
 
 // eslint-disable-next-line @typescript-eslint/no-shadow
-const external = ['ol/control/Control', 'ol/PluggableMap', 'ol'];
+const external = ['ol/control/Control', 'ol/events/Event', 'ol/PluggableMap', 'ol'];
 const globals = {
     'ol/control/Control': 'ol.control.Control',
+    'ol/events/Event': 'ol.events.Event',
     ol: 'ol',
 };
 


### PR DESCRIPTION
Hi, i made some minor fixes:
- Fixed issue #236 moving the emitter to the setMap method and using `emitter.off` to desubscribe the problematic events.
- Fixed typescript errors on events, referenced on issue #233 
- Added `originalEvent` attribute on the mouse events
- Re-added the `open` event that was missing after commit https://github.com/jonataswalker/ol-contextmenu/commit/f1608b299b386ec7ede47fb7afa86144d3c4e91d (but still included in the documentation)

Let me know if changes are required, hope it helps.