### PR TITLE
Fix menu positioning

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -328,7 +328,7 @@ export default class ContextMenu extends Control {
             w: this.container.offsetWidth,
             // a cheap way to recalculate container height
             // since offsetHeight is like cached
-            h: Math.round(this.lineHeight * this.getMenuEntriesLength()),
+            h: this.container.offsetHeight,
         };
 
         const left = spaceLeft.w >= menuSize.w ? this.pixel[0] + 5 : this.pixel[0] - menuSize.w;


### PR DESCRIPTION
`positionContainer()` might calculate a wrong value for
the height of the menu. That happens when items are
dynamically added / removed `beforeOpen` and not on startup.
The previously used `lineHeight `is only calculated initially.

`getMenuEntriesLength()` returns the total amount of menu items.
This includes subitems which are not relevant for the height
of the contextmenu.

#242 