### PR TITLE
Added ./* to package exports field

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,11 @@
             "import": "./dist/ol-contextmenu.css",
             "require": "./dist/ol-contextmenu.css",
             "style": "./dist/ol-contextmenu.css"
+        },
+        "./*": {
+            "import": "./*",
+            "require": "./*",
+            "style": "./*"
         }
     },
     "files": [


### PR DESCRIPTION
This addition is to allow bundlers that don't support the "exports" field to work together with others that do. On the other hand, it will help in the future to prevent modules from breaking once they add support for the use of the "exports" field.

Example: if ol-contextmenu is used in a module bundled with Rollup and PostCSS, the "exports" field is not taken into account at the scss @import, so the entire path is neccesary. But, if this new bundled module is then imported in another library using Webpack and PostCSS (which supports "exports"), will be a unresolvable conflict without this addition.