### PR TITLE
Add hideOnMove option to allow map to move without hiding context menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ contextmenu.on('open', function (evt) {
 -   `defaultItems`: `true`; Whether the default items (which are: Zoom In/Out) are enabled
 -   `width`: `150`; The menu's width
 -   `items`: `[]`; An array of object|string
+-   `hideOnMove`: `true`; Whether the context menu should hide when the map moves as a result of user iteraction or programmatically.
 
 ## Methods
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,6 +6,7 @@ export const DEFAULT_OPTIONS: Options = {
     eventType: EventTypes.CONTEXTMENU,
     defaultItems: true,
     items: [],
+    hideOnMove: true,
 };
 
 const NAMESPACE = 'ol-ctx-menu';

--- a/src/main.ts
+++ b/src/main.ts
@@ -399,7 +399,9 @@ export default class ContextMenu extends Control {
     }
 
     protected handleMapMove() {
-        this.closeMenu();
+        if (this.options.hideOnMove) {
+            this.closeMenu();
+        }
     }
 
     protected handleEntryCallback(evt: MouseEvent) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,4 +64,5 @@ export type Options = {
     eventType: `${EventTypes}`;
     defaultItems: boolean;
     items: Item[];
+    hideOnMove?: boolean;
 };


### PR DESCRIPTION
Allows a user to provide an option to the constructor to disable hiding the context menu when the map is moved, either through code or dragged by the user.

A default value of true is provided to preserve current behaviour.