### PR TITLE
Fixed `closeMenu` method in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ contextmenu.on('open', function (evt) {
 
 Remove all elements from the menu.
 
-#### contextmenu.close()
+#### contextmenu.closeMenu()
 
 Close the menu programmatically.
 


### PR DESCRIPTION
Fix the `closeMenu` method in the readme, which was listed as `close`. This typo must be related to #283