### PR TITLE
Fix gap of upward opening dynamically created contextmenu

### DIFF
--- a/src/helpers/dom.ts
+++ b/src/helpers/dom.ts
@@ -34,7 +34,11 @@ export function getLineHeight(container: HTMLDivElement): number {
     cloned.append(element2);
     container.parentNode?.append(cloned);
 
-    const height = cloned.offsetHeight / 2;
+    const clonedStyle = window.getComputedStyle(cloned);
+    const paddingTop = Number.parseInt(clonedStyle.paddingTop, 10);
+    const paddingBottom = Number.parseInt(clonedStyle.paddingBottom, 10);
+
+    const height = (cloned.offsetHeight - (paddingTop + paddingBottom)) / 2;
 
     container.parentNode?.removeChild(cloned);
 


### PR DESCRIPTION
Fixed example:
https://jsfiddle.net/473n9yeu/

The helper function getLineHeight calculates the height of a contextmenu entry by mocking two entries and divide the height of the container by two.
But this does not take the padding of the container into account. Padding must be substracted from the offsetHeight.

close #290 